### PR TITLE
V9.0.0/rtm

### DIFF
--- a/.docfx/includes/availability-default.md
+++ b/.docfx/includes/availability-default.md
@@ -1,1 +1,1 @@
-Availability: .NET 8, .NET 6 and .NET Standard 2.0
+Availability: .NET 9, .NET 8 and .NET Standard 2.0

--- a/.docfx/includes/availability-modern.md
+++ b/.docfx/includes/availability-modern.md
@@ -1,1 +1,1 @@
-Availability: .NET 8 and .NET 6
+Availability: .NET 9 and .NET 8

--- a/.docfx/toc.yml
+++ b/.docfx/toc.yml
@@ -1,4 +1,4 @@
 - name: Unitify API
-  href: api/Codebelt..Unitify.html
+  href: api/Codebelt.Unitify.html
 - name: NuGet
   href: packages

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.0.0-rc.1" />
-    <PackageVersion Include="Cuemon.Core" Version="9.0.0-rc.1" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="9.0.0" />
+    <PackageVersion Include="Cuemon.Core" Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net6.0.427-net8.0.403-9.0.100-rc.2.24474.11"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.404-9.0.100"
         }
     ]
 }


### PR DESCRIPTION
This pull request includes updates to various files to reflect the new .NET 9 availability, correct a link in the table of contents, update package versions, and change the Docker image used for testing environments.

Updates for .NET 9 availability:

* [`.docfx/includes/availability-default.md`](diffhunk://#diff-e7c6e56f92f2e9152c615f69aeb95db756fc7be579eacb9672a51ce58056b39aL1-R1): Updated availability to include .NET 9.
* [`.docfx/includes/availability-modern.md`](diffhunk://#diff-95558ec93b4ec78af969c1b9e8e996f17ebdfa5f4b3517b744884f00ecdb78e6L1-R1): Updated availability to include .NET 9.

Corrections and updates:

* [`.docfx/toc.yml`](diffhunk://#diff-256d890920ad7c63161c2cce769958ef1af2859b8cdc327f0f603b4f8cbd330eL2-R2): Corrected the link to the Unitify API documentation.
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L6-R7): Updated package versions for `Codebelt.Extensions.Xunit.App` and `Cuemon.Core` to version 9.0.0.
* [`testenvironments.json`](diffhunk://#diff-9b8e96d74f58d1bbdcf7d7b724a15bd55082811dec8775f77cd16f909e898ec4L12-R12): Updated the Docker image to a new version that includes .NET 8.0.404 and .NET 9.0.100.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated availability information to support .NET 9 alongside .NET 8 and .NET Standard 2.0.
- **Bug Fixes**
	- Corrected hyperlink reference for the "Unitify API" entry.
- **Chores**
	- Updated package versions for `Codebelt.Extensions.Xunit.App` and `Cuemon.Core`.
	- Modified Docker image version for the "Docker-Ubuntu" environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->