### PR TITLE
V9.0.5/service update

### DIFF
--- a/.docfx/Dockerfile.docfx
+++ b/.docfx/Dockerfile.docfx
@@ -1,4 +1,6 @@
-﻿FROM --platform=$BUILDPLATFORM nginx:1.28.0-alpine AS base
+﻿ARG NGINX_VERSION=1.29.0-alpine
+
+FROM --platform=$BUILDPLATFORM nginx:${NGINX_VERSION} AS base
 RUN rm -rf /usr/share/nginx/html/*
 
 FROM --platform=$BUILDPLATFORM codebeltnet/docfx:2.78.3 AS build
@@ -8,7 +10,7 @@ ADD [".", "docfx"]
 RUN cd docfx; \
     docfx build
 
-FROM nginx:1.28.0-alpine AS final
+FROM nginx:${NGINX_VERSION} AS final
 WORKDIR /usr/share/nginx/html
 COPY --from=build /build/docfx/wwwroot /usr/share/nginx/html
 

--- a/.github/workflows/pipelines.yml
+++ b/.github/workflows/pipelines.yml
@@ -62,7 +62,7 @@ jobs:
   sonarcloud:
     name: call-sonarcloud
     needs: [build,test]
-    uses: codebeltnet/jobs-sonarcloud/.github/workflows/default.yml@v1
+    uses: codebeltnet/jobs-sonarcloud/.github/workflows/default.yml@v2
     with:
       organization: geekle
       projectKey: unitify
@@ -80,7 +80,7 @@ jobs:
   codeql:
     name: call-codeql
     needs: [build,test]
-    uses: codebeltnet/jobs-codeql/.github/workflows/default.yml@v1
+    uses: codebeltnet/jobs-codeql/.github/workflows/default.yml@v2
     permissions:
       security-events: write
 

--- a/.nuget/Codebelt.Unitify/PackageReleaseNotes.txt
+++ b/.nuget/Codebelt.Unitify/PackageReleaseNotes.txt
@@ -1,3 +1,9 @@
+Version 9.0.5
+Availability: .NET 9 and .NET 8
+ 
+# ALM
+- CHANGED Dependencies have been upgraded to the latest compatible versions for all supported target frameworks (TFMs)
+ 
 Version 9.0.4
 Availability: .NET 9 and .NET 8
  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For more details, please refer to `PackageReleaseNotes.txt` on a per assembly ba
 > [!NOTE]  
 > Changelog entries prior to version 9.0.0 was migrated from previous versions of [Cuemon.Core](https://github.com/gimlichael/Cuemon/commit/83e0c7af2cdaa07351e878fa7276558838f2e7e6).
 
+## [9.0.5] - 2025-07-11
+
+This is a service update that focuses on package dependencies.
+
 ## [9.0.4] - 2025-06-16
 
 This is a service update that focuses on package dependencies.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.3" />
-    <PackageVersion Include="Cuemon.Core" Version="9.0.6" />
+    <PackageVersion Include="Codebelt.Extensions.Xunit.App" Version="10.0.4" />
+    <PackageVersion Include="Cuemon.Core" Version="9.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -9,7 +9,7 @@
         {
             "name": "Docker-Ubuntu",
             "type": "docker",
-            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.411-9.0.301"
+            "dockerImage": "gimlichael/ubuntu-testrunner:net8.0.412-9.0.302"
         }
     ]
 }


### PR DESCRIPTION
This pull request includes updates across several files to improve dependency management, update workflows, and enhance Docker configurations. The most important changes involve upgrading dependencies to their latest versions, updating the Dockerfile to use a dynamic versioning approach, and modifying GitHub workflows to use newer versions of reusable workflows.

### Dependency Updates:
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L6-R7): Upgraded `Codebelt.Extensions.Xunit.App` to version `10.0.4` and `Cuemon.Core` to version `9.0.7`.
* [`testenvironments.json`](diffhunk://#diff-9b8e96d74f58d1bbdcf7d7b724a15bd55082811dec8775f77cd16f909e898ec4L12-R12): Updated the Docker image for the Ubuntu test runner to `gimlichael/ubuntu-testrunner:net8.0.412-9.0.302`.
* [`.nuget/Codebelt.Unitify/PackageReleaseNotes.txt`](diffhunk://#diff-a0ca8ee5dc01d2fdb6ec30335429e0ec5c36af7e1678d5b222a798b72f602f3aR1-R6): Added release notes for version `9.0.5`, highlighting upgraded dependencies for all supported target frameworks.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R13): Added a changelog entry for version `9.0.5`, indicating it as a service update focusing on package dependencies.

### Workflow Updates:
* [`.github/workflows/pipelines.yml`](diffhunk://#diff-c40697b077557a99813200fa892d01ac2d8c5201799193bc34320cd9526ee802L65-R65): Updated the `sonarcloud` and `codeql` jobs to use version `v2` of their respective reusable workflows. [[1]](diffhunk://#diff-c40697b077557a99813200fa892d01ac2d8c5201799193bc34320cd9526ee802L65-R65) [[2]](diffhunk://#diff-c40697b077557a99813200fa892d01ac2d8c5201799193bc34320cd9526ee802L83-R83)

### Docker Configuration Enhancements:
* [`.docfx/Dockerfile.docfx`](diffhunk://#diff-70863c1d8336296a1b22f5dde97f88a008bdeea7298b1928e3125490099b66b4L1-R3): Introduced an `ARG` for `NGINX_VERSION` to dynamically specify the version (`1.29.0-alpine`) and updated the `FROM` statements to use this argument. [[1]](diffhunk://#diff-70863c1d8336296a1b22f5dde97f88a008bdeea7298b1928e3125490099b66b4L1-R3) [[2]](diffhunk://#diff-70863c1d8336296a1b22f5dde97f88a008bdeea7298b1928e3125490099b66b4L11-R13)