### PR TITLE
V10.y.z/fork support

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -22,7 +22,6 @@ jobs:
     name: initialize
     runs-on: ubuntu-24.04
     outputs:
-      is-fork-pr: ${{ steps.vars.outputs.is-fork-pr }}
       run-privileged-jobs: ${{ steps.vars.outputs.run-privileged-jobs }}
       strong-name-key-filename: ${{ steps.vars.outputs.strong-name-key-filename }}
       build-switches: ${{ steps.vars.outputs.build-switches }}
@@ -32,12 +31,10 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-            echo "is-fork-pr=true" >> "$GITHUB_OUTPUT"
             echo "run-privileged-jobs=false" >> "$GITHUB_OUTPUT"
             echo "strong-name-key-filename=" >> "$GITHUB_OUTPUT"
             echo "build-switches=-p:SkipSignAssembly=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is-fork-pr=false" >> "$GITHUB_OUTPUT"
             echo "run-privileged-jobs=true" >> "$GITHUB_OUTPUT"
             echo "strong-name-key-filename=unitify.snk" >> "$GITHUB_OUTPUT"
             echo "build-switches=" >> "$GITHUB_OUTPUT"
@@ -61,7 +58,7 @@ jobs:
 
   pack:
     name: call-pack
-    needs: [init, build]
+    needs: [build]
     strategy:
       matrix:
         configuration: [Debug, Release]
@@ -73,7 +70,7 @@ jobs:
 
   test_linux:
     name: call-test-linux
-    needs: [init, build]
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:
@@ -84,13 +81,13 @@ jobs:
       runs-on: ${{ matrix.arch == 'ARM64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
       configuration: ${{ matrix.configuration }}
       build-switches: -p:SkipSignAssembly=true
-      build: true
+      build: true # we need to build due to xUnitv3
       restore: true
       download-pattern: build-${{ matrix.configuration }}-${{ matrix.arch }}
 
   test_windows:
     name: call-test-windows
-    needs: [init, build]
+    needs: [build]
     strategy:
       fail-fast: false
       matrix:
@@ -101,7 +98,7 @@ jobs:
       runs-on: ${{ matrix.arch == 'ARM64' && 'windows-11-arm' || 'windows-2025' }}
       configuration: ${{ matrix.configuration }}
       build-switches: -p:SkipSignAssembly=true
-      build: true
+      build: true # we need to build due to xUnitv3
       restore: true
       download-pattern: build-${{ matrix.configuration }}-${{ matrix.arch }}
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,4 +1,5 @@
 name: Unitify CI Pipeline
+
 on:
   pull_request:
     branches: [main]
@@ -17,8 +18,34 @@ permissions:
   contents: read
 
 jobs:
+  init:
+    name: initialize
+    runs-on: ubuntu-24.04
+    outputs:
+      is-fork-pr: ${{ steps.vars.outputs.is-fork-pr }}
+      run-privileged-jobs: ${{ steps.vars.outputs.run-privileged-jobs }}
+      strong-name-key-filename: ${{ steps.vars.outputs.strong-name-key-filename }}
+      build-switches: ${{ steps.vars.outputs.build-switches }}
+    steps:
+      - id: vars
+        name: calculate workflow variables
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            echo "is-fork-pr=true" >> "$GITHUB_OUTPUT"
+            echo "run-privileged-jobs=false" >> "$GITHUB_OUTPUT"
+            echo "strong-name-key-filename=" >> "$GITHUB_OUTPUT"
+            echo "build-switches=-p:SkipSignAssembly=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is-fork-pr=false" >> "$GITHUB_OUTPUT"
+            echo "run-privileged-jobs=true" >> "$GITHUB_OUTPUT"
+            echo "strong-name-key-filename=unitify.snk" >> "$GITHUB_OUTPUT"
+            echo "build-switches=" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     name: call-build
+    needs: [init]
     strategy:
       matrix:
         arch: [X64, ARM64]
@@ -26,14 +53,15 @@ jobs:
     uses: codebeltnet/jobs-dotnet-build/.github/workflows/default.yml@v3
     with:
       configuration: ${{ matrix.configuration }}
-      strong-name-key-filename: unitify.snk
+      strong-name-key-filename: ${{ needs.init.outputs.strong-name-key-filename }}
+      build-switches: ${{ needs.init.outputs.build-switches }}
       runs-on: ${{ matrix.arch == 'ARM64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
       upload-build-artifact-name: build-${{ matrix.configuration }}-${{ matrix.arch }}
     secrets: inherit
 
   pack:
     name: call-pack
-    needs: [build]
+    needs: [init, build]
     strategy:
       matrix:
         configuration: [Debug, Release]
@@ -45,7 +73,7 @@ jobs:
 
   test_linux:
     name: call-test-linux
-    needs: [build]
+    needs: [init, build]
     strategy:
       fail-fast: false
       matrix:
@@ -56,13 +84,13 @@ jobs:
       runs-on: ${{ matrix.arch == 'ARM64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
       configuration: ${{ matrix.configuration }}
       build-switches: -p:SkipSignAssembly=true
-      build: true # we need to build due to xUnitv3
+      build: true
       restore: true
       download-pattern: build-${{ matrix.configuration }}-${{ matrix.arch }}
 
   test_windows:
     name: call-test-windows
-    needs: [build]
+    needs: [init, build]
     strategy:
       fail-fast: false
       matrix:
@@ -73,13 +101,14 @@ jobs:
       runs-on: ${{ matrix.arch == 'ARM64' && 'windows-11-arm' || 'windows-2025' }}
       configuration: ${{ matrix.configuration }}
       build-switches: -p:SkipSignAssembly=true
-      build: true # we need to build due to xUnitv3
+      build: true
       restore: true
       download-pattern: build-${{ matrix.configuration }}-${{ matrix.arch }}
 
   sonarcloud:
+    if: ${{ needs.init.outputs.run-privileged-jobs == 'true' }}
     name: call-sonarcloud
-    needs: [build,test_linux,test_windows]
+    needs: [init, build, test_linux, test_windows]
     uses: codebeltnet/jobs-sonarcloud/.github/workflows/default.yml@v3
     with:
       organization: geekle
@@ -88,16 +117,18 @@ jobs:
     secrets: inherit
 
   codecov:
+    if: ${{ needs.init.outputs.run-privileged-jobs == 'true' }}
     name: call-codecov
-    needs: [build,test_linux,test_windows]
+    needs: [init, build, test_linux, test_windows]
     uses: codebeltnet/jobs-codecov/.github/workflows/default.yml@v1
     with:
       repository: codebeltnet/unitify
     secrets: inherit
-          
+
   codeql:
+    if: ${{ needs.init.outputs.run-privileged-jobs == 'true' }}
     name: call-codeql
-    needs: [build,test_linux,test_windows]
+    needs: [init, build, test_linux, test_windows]
     uses: codebeltnet/jobs-codeql/.github/workflows/default.yml@v3
     permissions:
       security-events: write


### PR DESCRIPTION
This pull request updates the `.github/workflows/ci-pipeline.yml` workflow to improve handling of pull requests from forks and to centralize workflow variable management. The main changes include adding an initialization job to set workflow variables, updating job dependencies, and restricting privileged jobs to only run for trusted (non-fork) pull requests.

Workflow improvements:

* Added an `init` job that calculates and outputs key workflow variables, such as whether the PR is from a fork, whether privileged jobs should run, and build configuration options. Other jobs now use these outputs for configuration.
* Updated job dependencies so that all main jobs (`build`, `pack`, `test_linux`, `test_windows`, `sonarcloud`, `codecov`, `codeql`) depend on the new `init` job, ensuring consistent variable usage across jobs. [[1]](diffhunk://#diff-6aa4809fbc7f18724c21281e7408804202ca7692ad5a25b32167f8301906c850R21-R64) [[2]](diffhunk://#diff-6aa4809fbc7f18724c21281e7408804202ca7692ad5a25b32167f8301906c850L48-R76) [[3]](diffhunk://#diff-6aa4809fbc7f18724c21281e7408804202ca7692ad5a25b32167f8301906c850L59-R93) [[4]](diffhunk://#diff-6aa4809fbc7f18724c21281e7408804202ca7692ad5a25b32167f8301906c850L76-R111) [[5]](diffhunk://#diff-6aa4809fbc7f18724c21281e7408804202ca7692ad5a25b32167f8301906c850R120-R131)

Security and privileged job control:

* Added conditions to privileged jobs (`sonarcloud`, `codecov`, `codeql`) so they only run if the PR is not from a fork, enhancing security and preventing secrets exposure. [[1]](diffhunk://#diff-6aa4809fbc7f18724c21281e7408804202ca7692ad5a25b32167f8301906c850L76-R111) [[2]](diffhunk://#diff-6aa4809fbc7f18724c21281e7408804202ca7692ad5a25b32167f8301906c850R120-R131)

Configuration management:

* Centralized the assignment of `strong-name-key-filename` and `build-switches` to use values determined by the `init` job, rather than hardcoding them in each job.
* Ensured that all jobs use the correct build switches and artifact download patterns, maintaining consistency in the build and test process.

These changes make the CI pipeline more robust, secure, and easier to maintain, especially when handling contributions from external forks.